### PR TITLE
Update modifier to allow parent to be empty.

### DIFF
--- a/_bem.scss
+++ b/_bem.scss
@@ -29,7 +29,7 @@ $bem_separator_modifier: '--';
   @at-root {
     #{&}#{$bem_separator_modifier}#{$bem_item} {
       @content;
-      @extend #{$bem_parent};
+      @extend #{$bem_parent} !optional;
     }
   }
 }


### PR DESCRIPTION
Extend can fail if the parent block/element is empty, this makes the extend optional.